### PR TITLE
Task - Update privacy page following update to analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ site/*
 /.vs
 /.gitignore
 /.gitignore
+/DorsetExplorer-Docs.bat

--- a/DorsetExplorer-Docs.bat
+++ b/DorsetExplorer-Docs.bat
@@ -1,0 +1,3 @@
+@echo off
+cd C:\Development\DorsetExplorer-Docs
+C:\PROGRA~1\QGIS_3\apps\Python39\python -m mkdocs serve

--- a/DorsetExplorer-Docs.bat
+++ b/DorsetExplorer-Docs.bat
@@ -1,3 +1,0 @@
-@echo off
-cd C:\Development\DorsetExplorer-Docs
-C:\PROGRA~1\QGIS_3\apps\Python39\python -m mkdocs serve

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -4,37 +4,7 @@ We use cookies and other technologies to improve the site and understand how peo
 
 We only use 'Strictly necessary' cookies in DorsetExplorer, which are [exempt from requiring consent](https://ico.org.uk/for-organisations/guide-to-pecr/guidance-on-the-use-of-cookies-and-similar-technologies/how-do-we-comply-with-the-cookie-rules/#comply16). You can still disable these using your browsers controls, but your experience will be impacted and some functionality may not be available at all.
 
-## Cookies used on DorsetExplorer
-Cookies are small text files that are placed on your computer by websites that you visit. They are widely used in order to make websites work, or work more efficiently, as well as to provide information to the owners of the site. The table below explains the cookies we use and why.
-
-| Name | Purpose | Expires |
-| ---- | ------- | ------- |
-| BIGipServerGI-Geoserver-Pool (may change name in future)    | Network Management | At the end of your session |
-| BIGipServerGI-AnythingElse-Pool (may change name in future) | Network Management | At the end of your session |
-| TS0143df85 (may change name in future)                      | Network Management | At the end of your session |
-
- If you are logged in to DorsetExplorer, you will also have the following cookies set.
-
-| Name | Purpose | Expires |
-| ---- | ------- | ------- |
-| .AspNetCore.Cookies      | Authentication | At the end of your session or when you log out |
-| .AspNetCore.Antiforgery  | Security        | At the end of your session |
-
-Most web browsers allow some control of most cookies through the browser settings. Visit your browsers help page to find out more.
-
-## Other logging
-
-### Cloudflare Web Analytics
-
-We use Cloudflare Web Analytics to gather aggregated information to understand how visitors engage with DorsetExplorer. Cloudflare Web Analytics is a privacy respecting analytics provider which doesn't set cookies or track you individually in any way. You can learn more on their website - [https://www.cloudflare.com/en-gb/web-analytics/](https://www.cloudflare.com/en-gb/web-analytics/)
-
-### ApplicationInsights
-
-We use Microsoft ApplicationInsights to log usage and track errors. This cannot be used to identify you individually and is only used to monitor for issues and log searches and version usage at a high level.
-
-### Web server logs
-
-Our web servers, like all web servers, log requests and store them in a log file. This contains the URL you visited, how long it took to respond and your IP address. None of this can be tied to an individual and these are regularly deleted, and only used to gather high level statistics, investigate problems or spot abuse.
+Our full privacy and cookie policy for Dorset Council can be found at [www.dorsetcouncil.gov.uk/footer/privacy-and-cookies-policy](https://www.dorsetcouncil.gov.uk/footer/privacy-and-cookies-policy).
 
 ### Local Storage use
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -2,9 +2,7 @@
 
 We use cookies and other technologies to improve the site and understand how people are using it. This page lists what we use, why and what you can do to opt out.
 
-We only use 'Strictly necessary' cookies in DorsetExplorer, which are [exempt from requiring consent](https://ico.org.uk/for-organisations/guide-to-pecr/guidance-on-the-use-of-cookies-and-similar-technologies/how-do-we-comply-with-the-cookie-rules/#comply16). You can still disable these using your browsers controls, but your experience will be impacted and some functionality may not be available at all.
-
-Our full privacy and cookie policy for Dorset Council can be found at [www.dorsetcouncil.gov.uk/footer/privacy-and-cookies-policy](https://www.dorsetcouncil.gov.uk/footer/privacy-and-cookies-policy).
+Read the full [privacy and cookie policy on the Dorset Council website](https://www.dorsetcouncil.gov.uk/footer/privacy-and-cookies-policy).
 
 ### Local Storage use
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -2,7 +2,9 @@
 
 We use cookies and other technologies to improve the site and understand how people are using it. This page lists what we use, why and what you can do to opt out.
 
-Read the full [privacy and cookie policy on the Dorset Council website](https://www.dorsetcouncil.gov.uk/footer/privacy-and-cookies-policy).
+We only use 'Strictly necessary' cookies in DorsetExplorer, which are [exempt from requiring consent](https://ico.org.uk/for-organisations/guide-to-pecr/guidance-on-the-use-of-cookies-and-similar-technologies/how-do-we-comply-with-the-cookie-rules/#comply16). You can still disable these using your browsers controls, but your experience will be impacted and some functionality may not be available at all.
+
+Our full privacy and cookie policy for Dorset Council can be found at [www.dorsetcouncil.gov.uk/footer/privacy-and-cookies-policy](https://www.dorsetcouncil.gov.uk/footer/privacy-and-cookies-policy).
 
 ### Local Storage use
 


### PR DESCRIPTION
Once the new analytics options go live we will be using the main DC analytics and cookie controls. 

To ensure that the docs make sense I'm proposing that we remove the custom section from our documentation and just link to the main council site but. 

We also plan on removing the privacy button from DorsetExplorer but keeping the Terms one so it will not be quite as easy to get to the page but I think it should still be fine. We felt that having Cookie Preferences and Privacy was too much and it is possible to add links in the cookie control panel as well if required. 