### PR TITLE
Bump GH action deps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
-name: Deploy Docs 
+name: Deploy Docs
 on:
   push:
-    branches: 
+    branches:
       - main
 permissions:
   contents: write
@@ -9,13 +9,13 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           key: ${{ github.ref }}
           path: .cache
-      - run: pip install mkdocs-material 
+      - run: pip install mkdocs-material
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
Very similar to the PR in the other repo, just bumping the actions before they are deprecated.
![image](https://github.com/user-attachments/assets/dab97108-ca10-44a2-afb1-2ae3fd4d13f4)

Can confirm it works as expected in [my fork](https://github.com/Zoobdude/DorsetExplorer-Docs/actions/workflows/deploy.yml).